### PR TITLE
Update @userfront/react version to 0.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nextjs-example",
       "version": "0.1.0",
       "dependencies": {
-        "@userfront/react": "^0.3.1",
+        "@userfront/react": "^0.3.3",
         "jsonwebtoken": "^8.5.1",
         "next": "^12.3.1",
         "next-cookies": "^2.0.3",
@@ -235,21 +235,21 @@
       "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
     "node_modules/@userfront/core": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.4.6.tgz",
-      "integrity": "sha512-ZNDVW0VxRu85sR/lcADaQ7HXnE5gAH/Sq14Js2sVdx1OkXOp4aCzW+EfMkqYLZcv5Y4dnnQ5i5JDDNwMovbMEw==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.5.6.tgz",
+      "integrity": "sha512-Ge8b+1DzmlKt1+/N4ySgEM29RXzwysV0JtsB51EZVNksDAojQVvx6pB9Yh10D4xGj4/GoiGUbbs6XNv0ktIyKw==",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"
       }
     },
     "node_modules/@userfront/react": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@userfront/react/-/react-0.3.1.tgz",
-      "integrity": "sha512-DyYBhUJD/Ws1zv3PcxqNMHMZk68CyMWgjL7lghzwBxq1Uvq4yssJGIVL+X4mbGCR5f1Bcw9KktzGetwvD1SYgw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@userfront/react/-/react-0.3.3.tgz",
+      "integrity": "sha512-lXPRteWr74ZdQL2DFLqzKaSXb50wnGKI5w5GnLEgDGsBG3BAOvy2nEit3cYLT9jD/2g0L4gB5kVbZkmWZj67TA==",
       "dependencies": {
         "@anymod/core": "^0.1.51",
-        "@userfront/core": "^0.4.4"
+        "@userfront/core": "^0.5.6"
       },
       "engines": {
         "npm": ">=6.9.0"
@@ -732,21 +732,21 @@
       "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
     "@userfront/core": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.4.6.tgz",
-      "integrity": "sha512-ZNDVW0VxRu85sR/lcADaQ7HXnE5gAH/Sq14Js2sVdx1OkXOp4aCzW+EfMkqYLZcv5Y4dnnQ5i5JDDNwMovbMEw==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.5.6.tgz",
+      "integrity": "sha512-Ge8b+1DzmlKt1+/N4ySgEM29RXzwysV0JtsB51EZVNksDAojQVvx6pB9Yh10D4xGj4/GoiGUbbs6XNv0ktIyKw==",
       "requires": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"
       }
     },
     "@userfront/react": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@userfront/react/-/react-0.3.1.tgz",
-      "integrity": "sha512-DyYBhUJD/Ws1zv3PcxqNMHMZk68CyMWgjL7lghzwBxq1Uvq4yssJGIVL+X4mbGCR5f1Bcw9KktzGetwvD1SYgw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@userfront/react/-/react-0.3.3.tgz",
+      "integrity": "sha512-lXPRteWr74ZdQL2DFLqzKaSXb50wnGKI5w5GnLEgDGsBG3BAOvy2nEit3cYLT9jD/2g0L4gB5kVbZkmWZj67TA==",
       "requires": {
         "@anymod/core": "^0.1.51",
-        "@userfront/core": "^0.4.4"
+        "@userfront/core": "^0.5.6"
       }
     },
     "axios": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@userfront/react": "^0.3.1",
+    "@userfront/react": "^0.3.3",
     "jsonwebtoken": "^8.5.1",
     "next": "^12.3.1",
     "next-cookies": "^2.0.3",


### PR DESCRIPTION
Update `@userfront/react` to 0.3.3

Includes fix for an issue where `Userfront.init()` throws in the NextJS server-side rendering environment.

Ref https://github.com/userfront/userfront-core/pull/134